### PR TITLE
Banish the duplicate pyres to the depths of hell

### DIFF
--- a/Defs/Dropdowns.xml
+++ b/Defs/Dropdowns.xml
@@ -204,9 +204,6 @@
         <defName>Ferny_Pyres</defName>
     </DesignatorDropdownGroupDef>
     <DesignatorDropdownGroupDef>
-        <defName>Ferny_Pyres</defName>
-    </DesignatorDropdownGroupDef>
-    <DesignatorDropdownGroupDef>
         <defName>Ferny_DisplayShelves</defName>
     </DesignatorDropdownGroupDef>
     <DesignatorDropdownGroupDef>


### PR DESCRIPTION
Why is this mod haunted by this duplicate DesignatorDropdownGroupDef?