### PR TITLE
Fix DesignatorDropdownGroupDefs for Dark Ages - Crypts and Tombs

### DIFF
--- a/Defs/Dropdowns.xml
+++ b/Defs/Dropdowns.xml
@@ -153,7 +153,10 @@
         <defName>Ferny_ConveyorBelts</defName>
     </DesignatorDropdownGroupDef>
     <DesignatorDropdownGroupDef>
-        <defName>Ferny_SepulchralRequiaries</defName>
+        <defName>Ferny_SepulchralReliquaries</defName>
+    </DesignatorDropdownGroupDef>
+    <DesignatorDropdownGroupDef>
+        <defName>Ferny_CryptStatues</defName>
     </DesignatorDropdownGroupDef>
     <DesignatorDropdownGroupDef>
         <defName>Ferny_Beds</defName>


### PR DESCRIPTION
This pull request makes updates to the `Defs/Dropdowns.xml` file, correcting a typo in a defName and adding a missing DesignatorDropdownGroupDef.

Key changes:

### Typo Correction:
* Corrected a typo in the `defName` from `Ferny_SepulchralRequiaries` to `Ferny_SepulchralReliquaries`.

### New Entry Addition:
* Added a new `DesignatorDropdownGroupDef` entry with the `defName` `Ferny_CryptStatues`.